### PR TITLE
Add typing metadata for package reexports

### DIFF
--- a/keyringrs/__init__.pyi
+++ b/keyringrs/__init__.pyi
@@ -1,0 +1,3 @@
+from .keyringrs import CredentialType as CredentialType, Entry as Entry
+
+__all__ = ("Entry", "CredentialType")


### PR DESCRIPTION
Without __init__.pyi, mypy does not reliably know that Entry is re-exported from the package.

According to PEP 561 py.typed must be in package directory.