### PR TITLE
Align enum stubs with PyO3 types

### DIFF
--- a/keyringrs/keyringrs.pyi
+++ b/keyringrs/keyringrs.pyi
@@ -1,17 +1,10 @@
-from enum import Enum, auto
-from typing import Self
+from typing import ClassVar
 
-class CredentialType(Enum):
-    """
-    Enumeration of credential types. Use this to specify how the credential
-    should be stored or interpreted.
+class CredentialType:
+    """Native Rust credential type exposed by the extension module."""
 
-    :cvar Default: Default credential handling
-    :cvar KeyUtils: Credential handling using key utilities
-    """
-
-    Default = auto()
-    KeyUtils = auto()
+    Default: ClassVar["CredentialType"]
+    KeyUtils: ClassVar["CredentialType"]
 
 class Entry:
     """
@@ -26,7 +19,7 @@ class Entry:
         user: str,
         target: str | None = None,
         credential_type: CredentialType = CredentialType.Default,
-    ) -> Self:
+    ) -> "Entry":
         """
         Construct a new Entry instance.
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,9 @@
+import platform
+from keyringrs import CredentialType, Entry
+
+
+def test_imports():
+    assert Entry is not None
+    assert isinstance(CredentialType.Default, CredentialType)
+    if platform.system() == "linux":
+        assert isinstance(CredentialType.KeyUtils, CredentialType)


### PR DESCRIPTION
The native credentials enum type was exported as class instead of Python enum type as specified in the stub. We aligned the stub with the exported type. Also removes Self usage which is python 3.11 feature.