### PR TITLE
Make vendored DBus optional on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,15 @@ edition = "2021"
 name = "keyringrs"
 crate-type = ["cdylib"]
 
+[features]
+default = ["vendored-dbus"]
+vendored-dbus = ["keyring/vendored"]
+
 [dependencies]
 pyo3 = { version = "0.29.2", features = ["abi3", "abi3-py39"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-keyring = { version = "3.6.3", features = ["linux-native-sync-persistent", "crypto-rust", "vendored"] }
+keyring = { version = "3.6.3", features = ["linux-native-sync-persistent", "crypto-rust"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3.6.3", features = ["apple-native"] }


### PR DESCRIPTION
Keep vendored DBus enabled by default for self-contained PyPI and musllinux wheels, while allowing distributors such as conda-forge to build with --no-default-features and link against their packaged DBus library.