### PR TITLE
Make CredentialType cloning during argument extraction explicit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ fn to_py_err(err: Error) -> PyErr {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum CredentialType {
     Default = 0,


### PR DESCRIPTION
PyO3 previously cloned Clone pyclasses automatically when extracting owned arguments. Explicitly opt in because Entry construction accepts CredentialType by value. This preserves the existing behavior and silences the deprecation warning.